### PR TITLE
Add render config and env-based API URLs

### DIFF
--- a/front_end/src/Pages/Login.tsx
+++ b/front_end/src/Pages/Login.tsx
@@ -4,6 +4,8 @@ import { AuthContext } from "../Provider/Provider";
 import toast from "react-hot-toast";
 import { FcGoogle } from "react-icons/fc";
 
+const API_BASE_URL = import.meta.env.VITE_API_URL || "";
+
 const Login = () => {
     const location = useLocation();
     const navigate = useNavigate();
@@ -19,7 +21,7 @@ const Login = () => {
         setError(null);
 
         try {
-            const response = await fetch("http://localhost:8000/api/token/", {
+            const response = await fetch(`${API_BASE_URL}/api/token/`, {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",

--- a/front_end/src/components/BusinessFrom.tsx
+++ b/front_end/src/components/BusinessFrom.tsx
@@ -11,6 +11,8 @@ import {
 import AnalysisResults from "./AnalysisResults";
 import { AnalysisResult } from "../types/FormTypes";
 
+const API_BASE_URL = import.meta.env.VITE_API_URL || "";
+
 const parseAnalysisResult = (text: string) => {
     // split into sections
     const sections = text.split("\n\n").reduce((acc, block) => {
@@ -272,7 +274,7 @@ const BusinessForm = () => {
             }
 
             const reportResponse = await fetch(
-                `http://localhost:8000/api/reports/${reportId}/`,
+                `${API_BASE_URL}/api/reports/${reportId}/`,
                 {
                     headers: {
                         Authorization: `Bearer ${accessToken}`,
@@ -333,7 +335,7 @@ const BusinessForm = () => {
             if (refreshToken) {
                 try {
                     const refreshResponse = await fetch(
-                        "http://localhost:8000/api/token/refresh/",
+                        `${API_BASE_URL}/api/token/refresh/`,
                         {
                             method: "POST",
                             headers: {
@@ -361,7 +363,7 @@ const BusinessForm = () => {
                 }
             }
 
-            const response = await fetch("http://localhost:8000/api/analyze/", {
+            const response = await fetch(`${API_BASE_URL}/api/analyze/`, {
                 method: "POST",
                 headers: {
                     "Content-Type": "application/json",

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,5 @@
+services:
+  - type: static
+    name: aibusiness-frontend
+    buildCommand: "cd front_end && npm install && npm run build"
+    staticPublishPath: "front_end/dist"


### PR DESCRIPTION
## Summary
- use `API_BASE_URL` env var in Login and BusinessFrom components
- add render.yaml for deploying the static frontend

## Testing
- `npm run build` *(fails: Cannot find module 'vite/dist/node/chunks/dep-Dyl6b77n.js')*