### PR TITLE
Add Render deployment blueprint

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,23 @@
+services:
+  - type: web
+    name: ai-business-backend
+    env: python
+    buildCommand: pip install -r requirements.txt
+    startCommand: gunicorn backend.wsgi:application
+    envVars:
+      - key: SECRET_KEY
+        sync: false
+      - key: OPENAI_API_KEY
+        sync: false
+      - key: DATABASE_URL
+        fromDatabase:
+          name: aibusiness-db
+          property: connectionString
+  - type: static
+    name: ai-business-frontend
+    buildCommand: cd front_end && npm install && npm run build
+    staticPublishPath: front_end/dist
+
+databases:
+  - name: aibusiness-db
+    plan: free


### PR DESCRIPTION
## Summary
- add `render.yaml` for Render services and database

## Testing
- `pytest backend/assessment/tests.py -q` *(fails: ModuleNotFoundError: No module named 'django')*